### PR TITLE
Fix archiveFileNames for xpack-dev-tools

### DIFF
--- a/package_recore_stm_index.json
+++ b/package_recore_stm_index.json
@@ -4,7 +4,7 @@
             "name": "RECore",
             "websiteURL": "https://omniment.co.jp",
             "maintainer": "OMNIMENT Inc.",
-            "email": "",
+            "email": "dummy",
             "help": {"online": "https://omniment.co.jp"},
             "platforms": [
                 {

--- a/package_recore_stm_index.json
+++ b/package_recore_stm_index.json
@@ -4,7 +4,7 @@
             "name": "RECore",
             "websiteURL": "https://omniment.co.jp",
             "maintainer": "OMNIMENT Inc.",
-            "email": "dummy",
+            "email": "",
             "help": {"online": "https://omniment.co.jp"},
             "platforms": [
                 {

--- a/package_recore_stm_index.json
+++ b/package_recore_stm_index.json
@@ -55,14 +55,14 @@
                         {
                             "host": "x86_64-apple-darwin",
                             "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v10.2.1-1.1/xpack-arm-none-eabi-gcc-10.2.1-1.1-darwin-x64.tar.gz",
-                            "archiveFileName": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v10.2.1-1.1/xpack-arm-none-eabi-gcc-10.2.1-1.1-linux-ia32.tar.gz",
+                            "archiveFileName": "xpack-arm-none-eabi-gcc-10.2.1-1.1-linux-ia32.tar.gz",
                             "checksum": "SHA-256:061615d3e35d026cfa3ef8999f2bdaef2181b56e61029f58c8e0f1054bba046b",
                             "size": "183654470"
                         },
                         {
                             "host": "x86_64-pc-linux-gnu",
                             "url": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v9.2.1-1.1/xpack-arm-none-eabi-gcc-10.2.1-1.1-linux-x64.tar.gz",
-                            "archiveFileName": "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v10.2.1-1.1/xpack-arm-none-eabi-gcc-10.2.1-1.1-linux-x64.tar.gz",
+                            "archiveFileName": "xpack-arm-none-eabi-gcc-10.2.1-1.1-linux-x64.tar.gz",
                             "checksum": "SHA-256:840e90b527d30143b8d8e5eb894218858ed14226bdc8664686f0848592b6e474",
                             "size": "188707051"
                         },


### PR DESCRIPTION
Previous archiveFileName (containing http://...) did not work for me. I think the solution is to delete prefix before file name.